### PR TITLE
Modify window behaviour

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *~
+com.*.json
 /build
 /subprojects/blueprint-compiler
 /.flatpak-builder

--- a/data/ui/window.blp
+++ b/data/ui/window.blp
@@ -2,11 +2,11 @@ using Gtk 4.0;
 using Adw 1;
 
 template $CaffeineWindow : Adw.ApplicationWindow {
-    default-width: 350;
+    default-width: 360;
     default-height: 400;
-    width-request: 300;
-    height-request: 300;
-    resizable: false;
+    width-request: 360;
+    height-request: 360;
+
     title: _("Caffeine");
     icon-name: "com.konstantintutsch.Caffeine";
 
@@ -25,7 +25,7 @@ template $CaffeineWindow : Adw.ApplicationWindow {
 
             [start]
             Gtk.Button about_button {
-                css-classes: ["image-button"];
+                styles ["image-button"]
                 icon-name: "help-about-symbolic";
                 tooltip-text: _("About Caffeine");
             }
@@ -86,7 +86,7 @@ template $CaffeineWindow : Adw.ApplicationWindow {
                         spacing: 10;
 
                         Gtk.Button ratio_button {
-                            css-classes: ["title-1", "pill"];                        
+                            styles ["title-1", "pill"]
                             label: _("No data");
                             tooltip-text: _("Copy ratio");
                         }


### PR DESCRIPTION
This pull request makes the `AdwAboutDialog` display correctly inside of the window. (An `AdwDialog` cannot be displayed inside of an un-resizable window, for some reason.) Some blueprint things are also updated to give more commonly used patterns for CSS classes.

<img width=400 title="Skjermbilde fra 2024-10-15 21-13-33" src="https://github.com/user-attachments/assets/d4cbd17a-88fa-4713-a675-9569342100f3">


I also noticed that the version is set fast in the code for the about dialog. If you want, I can make the build version load in from Meson, so that this does not need to be altered every release.