### PR TITLE
desktop: Add GTK keyword to categories list.

### DIFF
--- a/data/com.konstantintutsch.Caffeine.desktop.in.in
+++ b/data/com.konstantintutsch.Caffeine.desktop.in.in
@@ -4,5 +4,5 @@ Name=Caffeine
 Icon=@project_id@
 StartupNotify=true
 Exec=@project_exec@
-Categories=Utility;Calculator;GNOME;
+Categories=Utility;Calculator;GNOME;GTK;
 Keywords=coffee;recipe;ratio;


### PR DESCRIPTION
Fixes complaint from desktop-file-validate:
Value item "GNOME" in key "Categories" in group "Desktop Entry" can be extended with another category among the following categories: GTK